### PR TITLE
Fixes pattern for Swift and added pattern for Objective-C.

### DIFF
--- a/Classes/main.swift
+++ b/Classes/main.swift
@@ -69,11 +69,13 @@ func listAssets() -> [String] {
 
 func localizedStrings(inStringFile: String) -> [String] {
     var localizedStrings = [String]()
+    let namePattern = "([\\w-]+)"
     let patterns = [
-        "#imageLiteral\\(resourceName: \"([\\w-]+)\"\\)", // Image Literal
-        "UIImage\\(named: \"(\\w+)\"\\)", // Default UIImage call
-        "\\<image name=\"([\\w-]+)\".*", // Storyboard resources
-        "R.image.([\\w-]+)\\(\\)" //R.swift support
+        "#imageLiteral\\(resourceName: \"\(namePattern)\"\\)", // Image Literal
+        "UIImage\\(named: \"\(namePattern)\"\\)", // Default UIImage call (Swift)
+        "UIImage imageNamed:\\@\"\(namePattern)\"", // Default UIImage call (Objective-C)
+        "\\<image name=\"\(namePattern)\".*", // Storyboard resources
+        "R.image.\(namePattern)\\(\\)" //R.swift support
     ]
     for p in patterns {
         let regex = try? NSRegularExpression(pattern: p, options: [])

--- a/Classes/main.swift
+++ b/Classes/main.swift
@@ -72,8 +72,8 @@ func localizedStrings(inStringFile: String) -> [String] {
     let namePattern = "([\\w-]+)"
     let patterns = [
         "#imageLiteral\\(resourceName: \"\(namePattern)\"\\)", // Image Literal
-        "UIImage\\(named: \"\(namePattern)\"\\)", // Default UIImage call (Swift)
-        "UIImage imageNamed:\\@\"\(namePattern)\"", // Default UIImage call (Objective-C)
+        "UIImage\\(named:\\s*\"\(namePattern)\"\\)", // Default UIImage call (Swift)
+        "UIImage imageNamed:\\s*\\@\"\(namePattern)\"", // Default UIImage call 
         "\\<image name=\"\(namePattern)\".*", // Storyboard resources
         "R.image.\(namePattern)\\(\\)" //R.swift support
     ]


### PR DESCRIPTION
Hi,

I've created a PR for the 'pattern-matching'. For Swift the pattern `(\\w+)` was used, but this will not match dashes in filenames. So I decided to put the pattern in a variable and use that for a various types.

Also added support for de default Objective-C call